### PR TITLE
feat: add docs-links-check ci and fix dead links

### DIFF
--- a/.github/workflows/docs-links-check-pr.yml
+++ b/.github/workflows/docs-links-check-pr.yml
@@ -1,0 +1,33 @@
+name: Check links for modified docs
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+
+jobs:
+  docs-links-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@master
+
+      - name: Check links for mdx files 🔎
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'yes' # only show errors in output.
+          # use-verbose-mode: 'yes' # show detailed HTTP status for checked links.
+          # refer to https://github.com/tcort/markdown-link-check#config-file-format
+          config-file: '.github/workflows/docs.links.check.config.json'
+          check-modified-files-only: 'yes'
+          file-extension: '.mdx'
+
+      - name: Check links for markdown files 🔎
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'yes' # only show errors in output.
+          # use-verbose-mode: 'yes' # show detailed HTTP status for checked links.
+          # refer to https://github.com/tcort/markdown-link-check#config-file-format
+          config-file: '.github/workflows/docs.links.check.config.json'
+          check-modified-files-only: 'yes'
+          file-extension: '.md'

--- a/.github/workflows/docs-links-check.yml
+++ b/.github/workflows/docs-links-check.yml
@@ -1,0 +1,23 @@
+name: Docs Links Check
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * 6" # runs every saturday at 12:00 UTC
+
+jobs:
+  docs-links-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@master
+
+      - name: Check Links 🔎
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'yes' # only show errors in output.
+          # use-verbose-mode: 'yes' # show detailed HTTP status for checked links.
+          folder-path: 'docs/' # only check the docs/ folder
+          # refer to https://github.com/tcort/markdown-link-check#config-file-format
+          config-file: '.github/workflows/docs.links.check.config.json'
+          file-extension: '.md*' # .md or .mdx

--- a/.github/workflows/docs.links.check.config.json
+++ b/.github/workflows/docs.links.check.config.json
@@ -1,0 +1,16 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "^[^h]"
+        },
+        {
+            "pattern": "^http://localhost"
+        },
+        {
+            "pattern": "^http://yourip"
+        },
+        {
+            "pattern": "^http://your-ip"
+        }
+    ]
+}

--- a/docs/bt-panel.md
+++ b/docs/bt-panel.md
@@ -115,5 +115,5 @@ nohup ./main &
 ```
 Next visit **http://your-ip:7000**, click login, enter the account you added before, user_1/123, you have now successfully logged in to Casnode.  
 
-For more settings please see [Casnode.](https://casnode.org/docs)
+For more settings please see [casnode.org](https://casnode.org/docs/overview).
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -69,5 +69,5 @@ docker-compose up
 
 Next visit http://your-ip:7000, click login, enter the account you added before, user_1/123, you have now successfully logged in to Casnode.  
 
-More settings reference [casnode.](https://casnode.org/docs)
+More settings reference [casnode.org](https://casnode.org/docs/overview).
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -67,7 +67,7 @@ casdoorDbName = casdoor
 :::tip
 
 Casdoor's `driverName` and `dataSourceName` are the same as casnode by default. If your Casdoor and Casnode are not
-in the same database, you can set up the casdoor database in [casdoor/adapter.go](https://github.com/casbin/casnode/casdoor/adapter.go)
+in the same database, you can set up the casdoor database in [casdoor/adapter.go](https://github.com/casbin/casnode/blob/master/casdoor/adapter.go)
 
 Here we provide an example:
 


### PR DESCRIPTION
done: #92 

This ci will run every saturday at 12:00 UTC

This ci can be manually triggered on the [Action page](https://github.com/casnode/casnode-website/actions/workflows/docs-links-check.yml)

When modifying or adding docs in PR, the ci will run to check whether there is a dead link.

`docs.links.check.config.json` is the config file of this ci, refer to https://github.com/tcort/markdown-link-check#config-file-format .

There are ignorePatterns in the file for ignoring some links, for example:

```md
[](overview)
[](/img/casbin.png)
[](http://localhost:8000)
```